### PR TITLE
Add Promise support

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -109,6 +109,19 @@ internals.getItems = function (table, serializer) {
       options = {};
     }
 
+    var promise;
+    if (Promise && typeof callback !== 'function') {
+      promise = new Promise(function (resolve, reject) {
+        callback = function (err, results) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(results);
+          }
+        };
+      });
+    }
+
     async.map(internals.buckets(_.clone(keys)), function (key, callback) {
       internals.initialBatchGetItems(key, table, serializer, options, callback);
     }, function (err, results) {
@@ -118,6 +131,8 @@ internals.getItems = function (table, serializer) {
 
       return callback(null, _.flatten(results));
     });
+
+    return promise;
   };
 
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,10 +170,21 @@ dynamo.createTables = function (options, callback) {
     options = {};
   }
 
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   callback = callback || _.noop;
   options = options || {};
 
-  return createTables(dynamo.models, options, callback);
+  createTables(dynamo.models, options, callback);
+
+  return promise;
 };
 
 dynamo.types = Schema.types;

--- a/lib/item.js
+++ b/lib/item.js
@@ -34,6 +34,16 @@ Item.prototype.set = function (params) {
 
 Item.prototype.save = function (callback) {
   var self = this;
+  
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   callback = callback || internals.identity;
 
   self.table.create(this.attrs, function (err, item) {
@@ -45,6 +55,8 @@ Item.prototype.save = function (callback) {
 
     return callback(null, item);
   });
+
+  return promise;
 };
 
 Item.prototype.update = function (options, callback) {
@@ -56,6 +68,16 @@ Item.prototype.update = function (options, callback) {
   }
 
   options = options || {};
+
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   callback = callback || internals.identity;
 
   self.table.update(this.attrs, options, function (err, item) {
@@ -69,6 +91,8 @@ Item.prototype.update = function (options, callback) {
 
     return callback(null, item);
   });
+
+  return promise;
 };
 
 Item.prototype.destroy = function (options, callback) {
@@ -80,9 +104,21 @@ Item.prototype.destroy = function (options, callback) {
   }
 
   options = options || {};
+
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   callback = callback || internals.identity;
 
   self.table.destroy(this.attrs, options, callback);
+
+  return promise;
 };
 
 Item.prototype.toJSON = function() {

--- a/lib/parallelScan.js
+++ b/lib/parallelScan.js
@@ -19,7 +19,7 @@ ParallelScan.prototype.exec = function (callback) {
   var self = this;
 
   var streamMode = false;
-  var combinedStream = new Readable({objectMode: true});
+  var combinedStream = utils.promisifyStream(new Readable({objectMode: true}));
 
   if(!callback) {
     streamMode = true;

--- a/lib/table.js
+++ b/lib/table.js
@@ -90,6 +90,15 @@ Table.prototype.get = function (hashKey, rangeKey, options, callback) {
     options = {};
   }
 
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   var params = {
     TableName : self.tableName(),
     Key : self.serializer.buildKey(hashKey, rangeKey, self.schema)
@@ -109,6 +118,8 @@ Table.prototype.get = function (hashKey, rangeKey, options, callback) {
 
     return callback(null, item);
   });
+  
+  return promise;
 };
 
 internals.callBeforeHooks = function (table, name, startFun, callback) {
@@ -125,6 +136,15 @@ Table.prototype.create = function (item, options, callback) {
     options = {};
   }
 
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   callback = callback || _.noop;
   options = options || {};
 
@@ -133,8 +153,10 @@ Table.prototype.create = function (item, options, callback) {
       return internals.createItem(self, data, options, callback);
     }, callback);
   } else {
-    return internals.createItem(self, item, options, callback);
+    internals.createItem(self, item, options, callback);
   }
+
+  return promise;
 };
 
 internals.createItem = function (table, item, options, callback) {
@@ -239,6 +261,15 @@ Table.prototype.update = function (item, options, callback) {
     options = {};
   }
 
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   callback = callback || _.noop;
   options = options || {};
 
@@ -305,6 +336,8 @@ Table.prototype.update = function (item, options, callback) {
     });
 
   });
+
+  return promise;
 };
 
 internals.addConditionExpression = function (params, expectedConditions) {
@@ -358,6 +391,15 @@ Table.prototype.destroy = function (hashKey, rangeKey, options, callback) {
     options = {};
   }
 
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
+
   callback = callback || _.noop;
   options = options || {};
 
@@ -392,6 +434,8 @@ Table.prototype.destroy = function (hashKey, rangeKey, options, callback) {
     self._after.emit('destroy', item);
     return callback(null, item);
   });
+
+  return promise;
 };
 
 Table.prototype.query = function (hashKey) {
@@ -571,15 +615,34 @@ Table.prototype.createTable = function (options, callback) {
 };
 
 Table.prototype.describeTable = function (callback) {
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err, results) {
+        err ? reject(err) : resolve(results);
+      };
+    });
+  }
 
   var params = {
     TableName : this.tableName(),
   };
 
   this.sendRequest('describeTable', params, callback);
+
+  return promise;
 };
 
 Table.prototype.deleteTable = function (callback) {
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err) {
+        err ? reject(err) : resolve();
+      };
+    });
+  }
+
   callback = callback || _.noop;
 
   var params = {
@@ -587,6 +650,8 @@ Table.prototype.deleteTable = function (callback) {
   };
 
   this.sendRequest('deleteTable', params, callback);
+
+  return promise;
 };
 
 Table.prototype.updateTable = function (throughput, callback) {
@@ -596,6 +661,15 @@ Table.prototype.updateTable = function (throughput, callback) {
     throughput = {};
   }
 
+  var promise;
+  if (!callback && Promise) {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (err) {
+        err ? reject(err) : resolve();
+      };
+    });
+  }
+
   callback = callback || _.noop;
   throughput = throughput || {};
 
@@ -603,6 +677,8 @@ Table.prototype.updateTable = function (throughput, callback) {
     async.apply(internals.syncIndexes, self),
     async.apply(internals.updateTableCapacity, self, throughput),
   ], callback);
+
+  return promise;
 };
 
 internals.updateTableCapacity = function (table, throughput, callback) {
@@ -624,7 +700,7 @@ internals.updateTableCapacity = function (table, throughput, callback) {
     params.TableName = table.tableName();
     table.sendRequest('updateTable', params, callback);
   } else {
-    return callback();
+    callback();
   }
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 var _        = require('lodash'),
     Readable = require('stream').Readable,
+    streamToPromise = require('stream-to-promise'),
     async    = require('async'),
     AWS      = require('aws-sdk');
 
@@ -114,7 +115,7 @@ utils.streamRequest = function (self, runRequestFunc) {
   var lastEvaluatedKey = null;
   var performRequest = true;
 
-  var stream = new Readable({objectMode: true});
+  var stream = utils.promisifyStream(new Readable({objectMode: true}));
 
   var startRead = function () {
     if(!performRequest) {
@@ -149,6 +150,19 @@ utils.streamRequest = function (self, runRequestFunc) {
 
   stream._read = function () {
     startRead();
+  };
+
+  return stream;
+};
+
+utils.promisifyStream = function (stream) {
+  if (!Promise) {
+    // If promises are not supported, do not support the promise() method on streams.
+    return stream;
+  }
+
+  stream.promise = function () {
+    return streamToPromise(stream);
   };
 
   return stream;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "bunyan": "1.5.x",
     "joi": "5.x.x",
     "lodash": "4.x.x",
-    "node-uuid": "1.4.x"
+    "node-uuid": "1.4.x",
+    "stream-to-promise": "~2.2.0"
   },
   "devDependencies": {
     "chai": "1.x.x",

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -6,6 +6,7 @@ var dynamo = require('../index'),
     Table  = require('../lib/table'),
     chai   = require('chai'),
     expect = chai.expect,
+    assert = chai.assert,
     Joi    = require('joi'),
     sinon  = require('sinon');
 
@@ -202,6 +203,26 @@ describe('dynamo', function () {
         expect(dynamodb.describeTable.calledOnce).to.be.true;
         return done();
       });
+    });
+
+    it('should reject an error with promises', function (done) {
+      var Account = dynamo.define('Account', {hashKey : 'id'});
+
+      var dynamodb = Account.docClient.service;
+      dynamodb.describeTable.onCall(0).yields(null, null);
+
+      dynamodb.createTable.yields(new Error('Fail'), null);
+
+      dynamo.createTables()
+        .then(function () {
+          assert(false, 'then should not be called');
+          done();
+        })
+        .catch(function (err) {
+          expect(err).to.exist;
+          expect(dynamodb.describeTable.calledOnce).to.be.true;
+          return done();
+        });
     });
 
     it('should create model without callback', function (done) {

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -5,6 +5,7 @@ var Item   = require('../lib/item'),
     Schema = require('../lib/schema'),
     chai   = require('chai'),
     expect = chai.expect,
+    assert = chai.assert,
     helper = require('./test-helper'),
     serializer = require('../lib/serializer'),
     Joi    = require('joi');
@@ -51,6 +52,22 @@ describe('item', function() {
         return done();
       });
 
+      it('should reject an error with a promise', function (done) {
+        table.docClient.put.yields(new Error('fail'));
+
+        var attrs = {num: 1, name: 'foo'};
+        var item = new Item(attrs, table);
+
+        item.save()
+          .then(function () {
+            assert(false, 'then should not be called');
+          })
+          .catch(function (err) {
+            expect(err).to.exist;
+
+            return done();
+          });
+      });
     });
 
   });
@@ -68,6 +85,23 @@ describe('item', function() {
 
         return done();
       });
+    });
+
+    it('should resolve to an item with a promise', function (done) {
+      table.docClient.update.yields(null, {Attributes : {num : 1, name : 'foo'}});
+
+      var attrs = {num: 1, name: 'foo'};
+      var item = new Item(attrs, table);
+
+      item.update()
+        .then(function (data) {
+          expect(data.get()).to.eql({ num : 1, name : 'foo'});
+
+          return done();
+        })
+        .catch(function () {
+          assert(false, 'catch should not be called');
+        });
     });
 
 

--- a/test/parallel-test.js
+++ b/test/parallel-test.js
@@ -62,4 +62,22 @@ describe('ParallelScan', function() {
 
   });
 
+  it('should promisify an error', function (done) {
+    var scan = new ParallelScan(table, serializer, 4);
+
+    table.docClient.scan.yields(new Error('fail'));
+
+    var promise = scan.exec().promise();
+    assert(typeof promise.then === 'function' && typeof promise.catch === 'function', 'Promise returned wasn\'t a promise.');
+
+    promise
+      .then(function () {
+        assert(false, 'then should not be called');
+      })
+      .catch(function (err) {
+        expect(err).to.exist;
+        return done();
+      });
+  });
+
 });


### PR DESCRIPTION
Adds a “promise()” method to the streams, which converts the stream into a Promise. The promise is handled in the same way as the streaming API, meaning the results are just returned in an array instead of embedded in an object.

Additionally, Promises are now supported on the create, get, update, and delete APIs for individual models, as well as the batch get items API.

New tests added for the various new Promise APIs, and they are all passing.

Fixes #1 