### PR TITLE
node-uuid is deprecated, use uuid instead

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Joi      = require('joi'),
-    nodeUUID = require('node-uuid'),
+    nodeUUID = require('uuid'),
     _        = require('lodash');
 
 var internals =  {};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bunyan": "1.5.x",
     "joi": "5.x.x",
     "lodash": "4.x.x",
-    "node-uuid": "1.4.x"
+    "uuid": "3.0.x"
   },
   "devDependencies": {
     "chai": "1.x.x",

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -6,7 +6,7 @@ var dynamo = require('../../index'),
     async  = require('async'),
     _      = require('lodash'),
     helper = require('../test-helper'),
-    uuid   = require('node-uuid'),
+    uuid   = require('uuid'),
     Joi    = require('joi');
 
 chai.should();


### PR DESCRIPTION
See the [node-uuid README](https://www.npmjs.com/package/node-uuid). For this package's purposes, the API is identical, so few changes are needed. Tested against the local dynamodb jar on MacOS 10.12.3.