### PR TITLE
deps(joi) upgraded Joi version from 5.x.x to 10.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: node_js
 node_js:
   - 4
   - 5
+  - 6
+  - 7
+  - 8
   - 0.10
   - 0.12
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -20,7 +20,7 @@ internals.configSchema = Joi.object().keys({
   hashKey   : Joi.string().required(),
   rangeKey  : Joi.string(),
   tableName : Joi.alternatives().try(Joi.string(), Joi.func()),
-  indexes   : Joi.array().includes(internals.secondaryIndexSchema),
+  indexes   : Joi.array().items(internals.secondaryIndexSchema),
   schema    : Joi.object(),
   timestamps : Joi.boolean().default(false),
   createdAt  : Joi.alternatives().try(Joi.string(), Joi.boolean()),
@@ -144,27 +144,36 @@ var Schema = module.exports = function (config) {
 Schema.types = {};
 
 Schema.types.stringSet = function () {
-  var set = Joi.array().includes(Joi.string()).meta({dynamoType : 'SS'});
+  var set = Joi.array().items(Joi.string()).meta({dynamoType : 'SS'});
 
   return set;
 };
 
 Schema.types.numberSet = function () {
-  var set = Joi.array().includes(Joi.number()).meta({dynamoType : 'NS'});
+  var set = Joi.array().items(Joi.number()).meta({dynamoType : 'NS'});
   return set;
 };
 
 Schema.types.binarySet = function () {
-  var set = Joi.array().includes(Joi.binary(), Joi.string()).meta({dynamoType : 'BS'});
+  var set = Joi.array().items(Joi.binary(), Joi.string()).meta({dynamoType : 'BS'});
   return set;
 };
 
+// Functions which can accept a single argument must be wrapped to avoid the
+// Joi context object from being passed as the first argument
+//
+// see :https://github.com/hapijs/joi/blob/v10.5.0/API.md#anydefaultvalue-description
+
 Schema.types.uuid = function () {
-  return Joi.string().guid().default(nodeUUID.v4);
+  return Joi.string().guid({version : 'uuidv4'}).default(function () {
+    return nodeUUID.v4();
+  }, 'nodeUUID.v4()');
 };
 
 Schema.types.timeUUID = function () {
-  return Joi.string().guid().default(nodeUUID.v1);
+  return Joi.string().guid({version : 'uuidv1'}).default(function () {
+    return nodeUUID.v4();
+  }, 'nodeUUID.v1()');
 };
 
 Schema.prototype.validate = function (params, options) {
@@ -187,6 +196,5 @@ internals.invokeDefaultFunctions = function (data) {
 
 Schema.prototype.applyDefaults = function (data) {
   var result = this.validate(data, {abortEarly : false});
-
   return internals.invokeDefaultFunctions(result.value);
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "async": "1.5.x",
     "aws-sdk": "2.2.x",
     "bunyan": "1.5.x",
-    "joi": "5.x.x",
+    "joi": "10.x.x",
     "lodash": "4.x.x",
     "node-uuid": "1.4.x"
   },

--- a/test/integration/create-table-test.js
+++ b/test/integration/create-table-test.js
@@ -376,7 +376,7 @@ describe('Update Tables Integration Tests', function() {
         UserId            : Joi.string(),
         TweetID           : dynamo.types.uuid(),
         content           : Joi.string(),
-        PublishedDateTime : Joi.date().default(Date.now)
+        PublishedDateTime : Joi.date().default(Date.now, 'Data.now()')
       }
     });
 
@@ -396,7 +396,7 @@ describe('Update Tables Integration Tests', function() {
         UserId            : Joi.string(),
         TweetID           : dynamo.types.uuid(),
         content           : Joi.string(),
-        PublishedDateTime : Joi.date().default(Date.now)
+        PublishedDateTime : Joi.date().default(Date.now, 'Date.now()')
       },
       indexes : [
         { hashKey : 'UserId', rangeKey : 'PublishedDateTime', type : 'global', name : 'PublishedDateTimeIndex'}

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -74,12 +74,17 @@ describe('Vogels Integration Tests', function() {
   this.timeout(0);
 
   before(function (done) {
+
+    function generateId () {
+      return uuid.v4();
+    }
+
     dynamo.dynamoDriver(helper.realDynamoDB());
 
     User = dynamo.define('dynamo-int-test-user', {
       hashKey : 'id',
       schema : {
-        id            : Joi.string().required().default(uuid.v4),
+        id            : Joi.string().default(generateId, 'uuid.v4'),
         email         : Joi.string().required(),
         name          : Joi.string().allow(''),
         age           : Joi.number().min(10),
@@ -104,7 +109,7 @@ describe('Vogels Integration Tests', function() {
         content           : Joi.string(),
         num               : Joi.number(),
         tag               : Joi.string(),
-        PublishedDateTime : Joi.date().default(Date.now)
+        PublishedDateTime : Joi.date().default(Date.now, 'Date.now()')
       },
       indexes : [
         { hashKey : 'UserId', rangeKey : 'PublishedDateTime', type : 'local', name : 'PublishedDateTimeIndex'}
@@ -124,7 +129,7 @@ describe('Vogels Integration Tests', function() {
           lastName  : Joi.string(),
           titles    : Joi.array()
         }),
-        actors : Joi.array().includes(Joi.object().keys({
+        actors : Joi.array().items(Joi.object().keys({
           firstName : Joi.string(),
           lastName  : Joi.string(),
           titles    : Joi.array()

--- a/test/parallel-test.js
+++ b/test/parallel-test.js
@@ -51,7 +51,6 @@ describe('ParallelScan', function() {
     var stream = scan.exec();
 
     stream.on('error', function (err) {
-      console.log('test here');
       expect(err).to.exist;
       return done();
     });

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -168,7 +168,7 @@ describe('schema', function () {
 
       expect(function () {
         new Schema(config);
-      }).to.throw(/hashKey is required/);
+      }).to.throw(/"hashKey" is required/);
 
     });
 
@@ -221,7 +221,7 @@ describe('schema', function () {
 
       expect(function () {
         new Schema(config);
-      }).to.throw(/hashKey must be one of context:hashKey/);
+      }).to.throw(/"hashKey" must be one of \[context:hashKey\]/);
     });
 
     it('should setup global index', function () {
@@ -247,7 +247,7 @@ describe('schema', function () {
 
       expect(function () {
         new Schema(config);
-      }).to.throw(/hashKey is required/);
+      }).to.throw(/"hashKey" is required/);
     });
 
     it('should parse schema data types', function () {
@@ -255,10 +255,10 @@ describe('schema', function () {
         hashKey : 'foo',
         schema : Joi.object().keys({
           foo  : Joi.string().default('foobar'),
-          date : Joi.date().default(Date.now),
+          date : Joi.date().default(Date.now, 'Using Date.now()'),
           count: Joi.number(),
           flag: Joi.boolean(),
-          nums : Joi.array().includes(Joi.number()).meta({dynamoType : 'NS'}),
+          nums : Joi.array().items(Joi.number()).meta({dynamoType : 'NS'}),
           items : Joi.array(),
           data : Joi.object().keys({
             stuff : Joi.array().meta({dynamoType : 'SS'}),
@@ -425,7 +425,7 @@ describe('schema', function () {
         hashKey : 'email',
         schema : {
           email : Joi.string(),
-          name  : Joi.string().default('Foo Bar').required(),
+          name  : Joi.string().default('Foo Bar'),
           age   : Joi.number().default(3)
         }
       };
@@ -446,10 +446,10 @@ describe('schema', function () {
         hashKey : 'email',
         schema : {
           email   : Joi.string(),
-          created : Joi.date().default(Date.now),
+          created : Joi.date().default(Date.now, 'Data.now()'),
           data : {
             name : Joi.string().default('Tim Tester'),
-            nick : Joi.string().default(_.constant('foo bar'))
+            nick : Joi.string().default(_.constant('foo bar'), 'using constant')
           }
         }
       };


### PR DESCRIPTION
This change updates the local version of Joi to the latest version range 10. Tests have been updated to reflect this change.

*Notable items*

- .contains() deprecated in favour of .items()
- Joi now insists upon supplying a description when a function is used as a default
- Revised UUID helper methods due to Joi change
- added additional node versions for testing