### PR TITLE
Update aws-sdk to 2.81.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "1.5.x",
-    "aws-sdk": "2.2.x",
+    "aws-sdk": "2.58.0",
     "bunyan": "1.5.x",
     "joi": "5.x.x",
     "lodash": "4.x.x",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "1.5.x",
-    "aws-sdk": "2.58.0",
+    "aws-sdk": "2.81.x",
     "bunyan": "1.5.x",
     "joi": "5.x.x",
     "lodash": "4.x.x",


### PR DESCRIPTION
A project I am currently working on uses ECS, but dynamodb was unable to get ECS task role credentials.  Credentials for ECS was added to aws-sdk in around 2.4.x and current package is aws-sdk 2.2.x.
