### PR TITLE
Feature/UUID upgrade

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Joi      = require('joi'),
-    nodeUUID = require('node-uuid'),
+    nodeUUID = require('uuid'),
     _        = require('lodash');
 
 var internals =  {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1470,11 +1470,6 @@
         }
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -1550,6 +1545,11 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bunyan": "1.5.x",
     "joi": "10.x.x",
     "lodash": "4.x.x",
-    "node-uuid": "1.4.x"
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "chai": "1.x.x",

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -6,7 +6,7 @@ var dynamo = require('../../index'),
     async  = require('async'),
     _      = require('lodash'),
     helper = require('../test-helper'),
-    uuid   = require('node-uuid'),
+    uuid   = require('uuid'),
     Joi    = require('joi');
 
 chai.should();


### PR DESCRIPTION
Switch from `node-uuid` to `uuid` package because they have merged and `node-uuid` is no longer maintained.