### PR TITLE
Modify dynamodb-local script to support persistence

### DIFF
--- a/test/bin/dynamodb-local
+++ b/test/bin/dynamodb-local
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
-wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -O /tmp/dynamodb_local_latest.tar.gz
-tar -xzf /tmp/dynamodb_local_latest.tar.gz -C /tmp
-java -Djava.library.path=/tmp/DynamoDBLocal_lib -jar /tmp/DynamoDBLocal.jar -inMemory &
+DB_EXECUTABLE=/tmp/dynamodb_local_latest.tar.gz
+DB_PATH=$1
+
+if [ ! -f $DB_EXECUTABLE ]
+then
+  wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -O $DB_EXECUTABLE
+  tar -xzf /tmp/dynamodb_local_latest.tar.gz -C /tmp
+fi
+
+if [ -z "$DB_PATH" ]
+then
+  java -Djava.library.path=/tmp/DynamoDBLocal_lib -jar /tmp/DynamoDBLocal.jar -inMemory &
+else
+  mkdir -p $DB_PATH
+  java -Djava.library.path=/tmp/DynamoDBLocal_lib -jar /tmp/DynamoDBLocal.jar -dbPath $DB_PATH
+fi


### PR DESCRIPTION
Hello,

This PR changes the `/test/bin/dynamodb-local` script to:
  • Don't download the latest dynamodb executable every time
  • Optionally pass in a data dir for dynamodb

This provides an easy way to start the local dynamodb (for dev and testing). A dependent project can easily wrap this and use it for starting a local DB 

e.g. 
```
"scripts" : {
  "dynamodb:local": "./node_modules/dynamodb/test/bin/dynamodb-local ./.data"
}
```