### PR TITLE
Fix hoek < 5.0.3 Vulnerability; Upgrade Joi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "1.5.x",
     "aws-sdk": "^2.186.x",
     "bunyan": "1.5.x",
-    "joi": "10.x.x",
+    "joi": "10.6.x",
     "lodash": "4.x.x",
     "node-uuid": "1.4.x"
   },

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -7,7 +7,7 @@ var sinon  = require('sinon'),
     bunyan = require('bunyan');
 
 exports.mockDynamoDB = function () {
-  var opts = { endpoint : 'http://localhost:8000', apiVersion: '2012-08-10' };
+  var opts = { endpoint : 'http://localhost:8000', region: 'us-west-2', apiVersion: '2012-08-10' };
   var db = new AWS.DynamoDB(opts);
 
   db.scan          = sinon.stub();
@@ -27,7 +27,7 @@ exports.mockDynamoDB = function () {
 };
 
 exports.realDynamoDB = function () {
-  var opts = { endpoint : 'http://localhost:8000', apiVersion: '2012-08-10' };
+  var opts = { endpoint : 'http://localhost:8000', region: 'us-west-2', apiVersion: '2012-08-10' };
   return new AWS.DynamoDB(opts);
 };
 


### PR DESCRIPTION
`hoek` node module before 5.0.3 or 4.2.1 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability.

For more information on , please see this link: https://nvd.nist.gov/vuln/detail/CVE-2018-3728