### PR TITLE
handle dynamoType

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -66,7 +66,7 @@ internals.parseDynamoTypes = function (data) {
   var mapped = _.reduce(data, function(result, val, key) {
     if(val.type === 'object' && _.isPlainObject(val.children)) {
       result[key] = internals.parseDynamoTypes(val.children);
-    } else if (val.type === 'array' && _.isArray(val.items) && val.items.length) {
+    } else if (val.type === 'array' && _.isArray(val.items) && val.items.length && (val.meta === undefined || val.meta.length < 1)) {
       result[key] = _.map(val.items, internals.parseDynamoTypes);
     } else {
       result[key] = internals.findDynamoTypeMetadata(val);


### PR DESCRIPTION
if an item has a meta array, don't treat it as a plain array.
fixes failing tests for 'NS' and 'SS'