### PR TITLE
Validate update against Schema

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -288,6 +288,12 @@ Table.prototype.update = function (item, options, callback) {
       return callback(err);
     }
 
+    var result = self.schema.validate(data);
+
+    if(result.error) {
+      return callback(result.error);
+    }
+
     var hashKey = data[self.schema.hashKey];
     var rangeKey = data[self.schema.rangeKey] || null;
 


### PR DESCRIPTION
Currently, update() does not validate against the associated Table schema. I do not believe this should be the desired behavior.