### PR TITLE
README: clarify comment about limit and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ BlogPost
   .select('COUNT')
   .exec(callback);
 
-// only return title and content attributes of 10 blog posts
+// Read 10 blog posts and only return title and content attributes of posts
 // that begin with the title Expanding
 BlogPost
   .query('werner@example.com')


### PR DESCRIPTION
The current README comment could be interpreted to mean that the query continues reading until it finds 10 entries matching the filters. In actual behavior, it reads 10 entries and returns only those that match the filters, like the corresponding Dynamo SDK call.
