### PR TITLE
fix: serialize item of type array with zero

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -139,7 +139,7 @@ serializer.buildKey = function (hashKey, rangeKey, schema) {
 
 serializer.serializeItem = function (schema, item, options = {}) {
   var serialize = function (value, datatypes = {}) {
-    if(!value) {
+    if(value === null) {
       return null;
     }
 

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -527,6 +527,22 @@ describe('Serializer', function () {
       item.objects.should.eql([{number: 10, string: 'd'}]);
     });
 
+    it('should serialize number array with zeros', function () {
+      var config = {
+        hashKey: 'id',
+        schema : {
+          id : Joi.number(),
+          resolution : Joi.array().items(Joi.number()).min(2).max(2),
+        }
+      };
+
+      var s = new Schema(config);
+
+      var item = serializer.serializeItem(s, {id: 1, resolution: [0, 0]});
+
+      item.should.eql({id: 1, resolution: [0, 0]});
+    });
+
     it('should return empty when serializing null value', function () {
       var config = {
         hashKey: 'email',


### PR DESCRIPTION
Currently the serialize in dynamodb will return `[null, null]` instead of `[0, 0]`.
Issue found in a not correct check at `lib/serializer.js:142`, the values `0` and `''` are result as null, because they are truish at this check.
Result of new test case without the changes on `lib/serializer.js` to see the issue:
```
Serializer
       #serializeItem
         should serialize number array with zeros:

      AssertionError: expected { id: 1, resolution: [ null, null ] } to deeply equal { id: 1, resolution: [ +0, +0 ] }
      + expected - actual

       {
         "id": 1
         "resolution": [
      -    [null]
      -    [null]
      +    0
      +    0
         ]
       }

      at Context.<anonymous> (test\serializer-test.js:543:19)
      at process.processImmediate (node:internal/timers:476:21)
```
